### PR TITLE
chore: add Astro scaffold with requirements and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM astrocrpublic.azurecr.io/runtime:3.0-10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Astro Runtime includes the following pre-installed providers packages: https://www.astronomer.io/docs/astro/runtime-image-architecture#provider-packages
+apache-airflow==2.9.*
+apache-airflow-providers-amazon
+boto3
+requests


### PR DESCRIPTION
What
- Add base Dockerfile for Astro runtime
- Add Airflow deps in requirements.txt

Why
- Establish minimal runtime so future DAG/dbt work has a stable base

How to test
- Clone, run: astro dev start
- Airflow webserver should start with no import errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preinstalls Apache Airflow 2.9.x, AWS provider packages, boto3, and requests, enabling workflow orchestration and AWS integrations out of the box.

* **Chores**
  * Introduces a Dockerfile based on the latest Astro Runtime image to standardize the execution environment.
  * Documents pre-installed provider packages in requirements for clarity and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->