### PR TITLE
fix: replace days_ago with timezone and use schedule param

### DIFF
--- a/dags/edgar_pipeline.py
+++ b/dags/edgar_pipeline.py
@@ -1,7 +1,7 @@
 from airflow import DAG
-from airflow.utils.dates import days_ago
-from airflow.operators.python import PythonOperator
-from airflow.operators.bash import BashOperator
+from airflow.utils import timezone
+from airflow.providers.standard.operators.python import PythonOperator
+from airflow.providers.standard.operators.bash import BashOperator
 
 def fetch_to_s3(**ctx):
     pass
@@ -11,11 +11,12 @@ def load_to_redshift(**ctx):
 
 with DAG(
     dag_id="edgar_pipeline",
-    start_date=days_ago(1),
-    schedule_interval=None,
+    start_date=timezone.datetime(2024, 1, 1),
+    schedule=None,
     catchup=False,
     default_args={"owner": "data-eng"},
 ) as dag:
+
 
     fetch_filings = PythonOperator(
         task_id="fetch_filings_to_s3",


### PR DESCRIPTION
- Replace deprecated days_ago import with airflow.utils.timezone
- Use schedule param instead of schedule_interval
- DAG loads cleanly under Runtime 3.0 Airflow 2.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated task to fetch EDGAR filings and store them in S3.

* **Chores**
  * Updated scheduling configuration to use modern parameters.
  * Standardized timezone handling with an explicit start date (Jan 1, 2024).
  * Refreshed operator imports to align with current Airflow providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->