### PR TITLE
feat: replace Redshift load with DuckDB load task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,5 @@
 FROM astrocrpublic.azurecr.io/runtime:3.0-10
+COPY requirements.txt /usr/local/airflow/requirements.txt
+RUN pip install --no-cache-dir -r /usr/local/airflow/requirements.txt
+COPY requirements-dev.txt /usr/local/airflow/requirements-dev.txt
+RUN pip install --no-cache-dir -r /usr/local/airflow/requirements-dev.txt

--- a/dags/scripts/duckdb_smoke.py
+++ b/dags/scripts/duckdb_smoke.py
@@ -1,0 +1,22 @@
+import os
+import duckdb
+
+
+def main():
+    duckdb_path = os.getenv("DUCKDB_PATH", "/data/edgar.duckdb")
+    con = duckdb.connect(duckdb_path)
+    try:
+        rows = con.execute(
+            "select form_type, count(*) as c from raw.edgar_master group by 1 order by 2 desc limit 10"
+        ).fetchall()
+        print("Top form_type counts:")
+        for r in rows:
+            print(f"{r[0]}\t{r[1]}")
+    finally:
+        con.close()
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 apache-airflow-providers-amazon
 boto3
 requests
-psycopg2-binary
 great_expectations
+duckdb
 

--- a/tests/test_dag_integrity.py
+++ b/tests/test_dag_integrity.py
@@ -6,7 +6,7 @@ def test_dag_loaded():
     dag = dag_bag.dags["edgar_pipeline"]
     assert [t.task_id for t in dag.tasks] == [
         "fetch_filings_to_s3",
-        "load_raw_to_redshift",
+        "load_duckdb",
         "run_dbt_models",
         "run_ge_validation",
     ]

--- a/tests/test_duckdb_load.py
+++ b/tests/test_duckdb_load.py
@@ -1,0 +1,37 @@
+import os
+import duckdb
+import boto3
+from moto import mock_aws
+from dags.edgar_pipeline import load_to_duckdb
+
+
+@mock_aws
+def test_load_to_duckdb_inserts_rows(tmp_path, monkeypatch):
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+    os.environ["EDGAR_S3_BUCKET"] = "test-bucket"
+    duckdb_path = tmp_path / "edgar.duckdb"
+    os.environ["DUCKDB_PATH"] = str(duckdb_path)
+
+    s3 = boto3.client("s3", region_name="us-east-1")
+    s3.create_bucket(Bucket="test-bucket")
+
+    ds = "20240131"
+    key = f"edgar/raw/master_index/{ds}.idx"
+    # Minimal idx sample with header and two rows
+    content = """CIK|Company Name|Form Type|Date Filed|Filename
+0000320193|Apple Inc.|10-K|2024-01-31|edgar/data/0000320193/0000320193-24-000010.txt
+0000789019|Microsoft Corp|10-Q|2024-01-31|edgar/data/0000789019/0000789019-24-000011.txt
+"""
+    s3.put_object(Bucket="test-bucket", Key=key, Body=content.encode("utf-8"))
+
+    load_to_duckdb(ds_nodash=ds)
+
+    con = duckdb.connect(str(duckdb_path))
+    count = con.execute("select count(*) from raw.edgar_master").fetchone()[0]
+    forms = con.execute("select form_type, count(*) from raw.edgar_master group by 1 order by 2 desc").fetchall()
+    con.close()
+
+    assert count == 2
+    assert ("10-K", 1) in forms and ("10-Q", 1) in forms
+
+

--- a/tests/test_fetch_task.py
+++ b/tests/test_fetch_task.py
@@ -11,7 +11,7 @@ from dags.edgar_pipeline import fetch_to_s3
 def test_fetch_to_s3_writes_to_s3(monkeypatch, ds):
     # 1) mock env + bucket
     os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-    os.environ["RAW_BUCKET"] = "test-bucket"
+    os.environ["EDGAR_S3_BUCKET"] = "test-bucket"
     s3 = boto3.client("s3", region_name="us-east-1")
     s3.create_bucket(Bucket="test-bucket")
 


### PR DESCRIPTION
Introduces DuckDB ingestion path, updates DAG, adds tests and smoke script, ensures env-only config. Had to shift away from Redshift do to potential cost concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added DuckDB-backed storage for EDGAR master data with local loading of index files.
  - Introduced a smoke-check script to display top filing types.
- Refactor
  - Replaced the Redshift loading step with a DuckDB-based task in the pipeline.
- Configuration
  - New DUCKDB_PATH setting (default: /data/edgar.duckdb).
  - Renamed S3 bucket environment variable to EDGAR_S3_BUCKET.
- Chores
  - Docker image now installs both runtime and development dependencies.
  - Updated dependencies: removed Redshift driver, added DuckDB.
- Tests
  - Added end-to-end test for DuckDB loading and updated pipeline expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->