### PR TITLE
feat: add retry/backoff logic to SEC fetch with unit test

### DIFF
--- a/tests/test_fetch_task.py
+++ b/tests/test_fetch_task.py
@@ -5,6 +5,7 @@ import boto3
 
 # import the function under test from your DAG file
 from dags.edgar_pipeline import fetch_to_s3
+from dags.utils import edgar_fetch
 
 @pytest.mark.parametrize("ds", ["20240131"])
 @mock_aws
@@ -26,3 +27,27 @@ def test_fetch_to_s3_writes_to_s3(monkeypatch, ds):
     key = f"edgar/raw/master_index/{ds}.idx"
     head = s3.head_object(Bucket="test-bucket", Key=key)
     assert head["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+
+def test_fetch_master_index_retries(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_get(url, headers=None, timeout=30):
+        class R:
+            def __init__(self, ok):
+                self._ok = ok
+                self.status_code = 200 if ok else 500
+                self.content = b"OK" if ok else b""
+
+            def raise_for_status(self):
+                if not self._ok:
+                    raise requests.HTTPError("500")
+
+        calls["n"] += 1
+        # Fail first two attempts, succeed on third
+        return R(ok=calls["n"] >= 3)
+
+    monkeypatch.setattr(edgar_fetch.requests, "get", fake_get)
+    out = edgar_fetch.fetch_master_index("20240131")
+    assert out == b"OK"
+    assert calls["n"] == 3


### PR DESCRIPTION
Retry and backoff logic to the SEC fetch function. Adds new unit test to verify retry behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Added automatic retries with exponential backoff when fetching the EDGAR master index, improving reliability under transient errors. Successful responses behave as before, including timing and content handling. No changes to public interfaces.

- Tests
  - Added unit tests covering retry behavior and maintained existing tests for S3 write flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->