### PR TITLE
feat: persist DuckDB via /data mount and add persistence test

### DIFF
--- a/dags/edgar_pipeline.py
+++ b/dags/edgar_pipeline.py
@@ -45,6 +45,10 @@ def load_to_duckdb(**ctx):
             continue
         records.append((cik.strip(), company_name.strip(), form_type.strip(), date_filed.strip(), filename.strip()))
 
+    # Ensure parent directory exists for persistence (e.g., mounted volume or bind mount)
+    parent_dir = os.path.dirname(duckdb_path) or "."
+    os.makedirs(parent_dir, exist_ok=True)
+
     con = duckdb.connect(duckdb_path)
     con.execute("create schema if not exists raw;")
     con.execute(

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  scheduler:
+    volumes:
+      - ./data:/data
+

--- a/tests/test_duckdb_persistence.py
+++ b/tests/test_duckdb_persistence.py
@@ -1,0 +1,50 @@
+import os
+import duckdb
+from dags.edgar_pipeline import load_to_duckdb
+
+
+def test_duckdb_path_parent_created(tmp_path, monkeypatch):
+    # Simulate a nested path under /tmp rather than /data to avoid needing a real mount
+    db_dir = tmp_path / "nested" / "dir"
+    db_path = db_dir / "edgar.duckdb"
+    monkeypatch.setenv("DUCKDB_PATH", str(db_path))
+
+    # Set S3 to a fake bucket and monkeypatch boto3 get_object to return sample idx
+    monkeypatch.setenv("EDGAR_S3_BUCKET", "test-bucket")
+
+    class FakeBody:
+        def __init__(self, data):
+            self._data = data
+
+        def read(self):
+            return self._data
+
+    def fake_get_object(Bucket=None, Key=None):
+        sample = (
+            b"CIK|Company Name|Form Type|Date Filed|Filename\n"
+            b"1|A|10-K|2024-01-31|f1\n"
+        )
+        return {"Body": FakeBody(sample)}
+
+    import dags.edgar_pipeline as ep
+    class FakeS3:
+        def get_object(self, Bucket=None, Key=None):
+            return fake_get_object(Bucket=Bucket, Key=Key)
+
+    # Patch boto3 client used in the module
+    import boto3 as real_boto3
+    monkeypatch.setattr(ep, "boto3", type("B", (), {"client": lambda *_args, **_kwargs: FakeS3()})())
+
+    # Run load task with a fixed date
+    load_to_duckdb(ds_nodash="20240131")
+
+    # Assert parent dir and DB were created and contain data
+    assert db_dir.exists()
+    con = duckdb.connect(str(db_path))
+    try:
+        cnt = con.execute("select count(*) from raw.edgar_master").fetchone()[0]
+        assert cnt == 1
+    finally:
+        con.close()
+
+


### PR DESCRIPTION
Adds docker-compose override to mount ./data -> /data for local persistence. Also ensure DUCKDB_PATH parent directory is created before connecting with test verifying nested DUCKDB_PATH creation and data write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure the DuckDB parent directory is created before writing, preventing failures when the target path is missing and improving data persistence reliability.
* **Chores**
  * Add a docker-compose override to mount a host data directory into the scheduler for persistent data sharing between host and container.
* **Tests**
  * Add an end-to-end test validating nested directory creation and successful data ingestion into DuckDB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->